### PR TITLE
Add temperature to home fragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,10 +61,8 @@ dependencies {
     implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha02'
     kapt 'androidx.hilt:hilt-compiler:1.0.0-alpha02'
 
-
     implementation "androidx.room:room-runtime:2.2.5"
     kapt "androidx.room:room-compiler:2.2.5"
-
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+apply plugin: 'dagger.hilt.android.plugin'
 
 def apikeyPropertiesFile = rootProject.file("apikey.properties")
 def apikeyProperties = new Properties()
@@ -15,6 +17,12 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "OWMAPIKEY", apikeyProperties['apikey'])
+
+        kapt {
+            arguments {
+                arg("room.schemaLocation", "$projectDir/schemas")
+            }
+        }
     }
     buildTypes {
         release {
@@ -46,6 +54,13 @@ dependencies {
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.android.gms:play-services-location:17.1.0'
     implementation 'com.google.code.gson:gson:2.8.6'
+
+    implementation "com.google.dagger:hilt-android:$hilt_version"
+    kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
+
+    implementation "androidx.room:room-runtime:2.2.5"
+    kapt "androidx.room:room-compiler:2.2.5"
+
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,9 +38,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
-    implementation 'androidx.navigation:navigation-fragment:2.3.0'
-    implementation 'androidx.navigation:navigation-ui:2.3.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.1'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.android.gms:play-services-location:17.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
 
+    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha02'
+    kapt 'androidx.hilt:hilt-compiler:1.0.0-alpha02'
+
+
     implementation "androidx.room:room-runtime:2.2.5"
     kapt "androidx.room:room-compiler:2.2.5"
 

--- a/app/schemas/com.rorpage.purtyweather.database.AppDatabase/1.json
+++ b/app/schemas/com.rorpage.purtyweather.database.AppDatabase/1.json
@@ -1,0 +1,46 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "fa7839d021bf9e200eb48c95d24fe6e9",
+    "entities": [
+      {
+        "tableName": "CurrentTemperature",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `temperature` REAL NOT NULL, `feelsLike` REAL NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feelsLike",
+            "columnName": "feelsLike",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fa7839d021bf9e200eb48c95d24fe6e9')"
+    ]
+  }
+}

--- a/app/src/main/java/com/rorpage/purtyweather/MainActivity.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/MainActivity.kt
@@ -11,8 +11,10 @@ import androidx.navigation.ui.NavigationUI
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.rorpage.purtyweather.managers.ServiceManager.startUpdateWeatherService
 import com.rorpage.purtyweather.util.WeatherUpdateScheduler.scheduleJob
+import dagger.hilt.android.AndroidEntryPoint
 import java.util.ArrayList
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/rorpage/purtyweather/PurtyWeatherApplication.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/PurtyWeatherApplication.kt
@@ -2,9 +2,11 @@ package com.rorpage.purtyweather
 
 import android.app.Application
 import com.android.volley.VolleyLog
+import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
+@HiltAndroidApp
 class PurtyWeatherApplication : Application() {
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/rorpage/purtyweather/database/AppDatabase.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/database/AppDatabase.kt
@@ -1,0 +1,12 @@
+package com.rorpage.purtyweather.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.rorpage.purtyweather.database.daos.CurrentTemperatureDAO
+import com.rorpage.purtyweather.database.entities.CurrentTemperature
+import com.rorpage.purtyweather.models.WeatherInfoUnit
+
+@Database(entities = [CurrentTemperature::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun currentTemperatureDAO(): CurrentTemperatureDAO
+}

--- a/app/src/main/java/com/rorpage/purtyweather/database/daos/CurrentTemperatureDAO.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/database/daos/CurrentTemperatureDAO.kt
@@ -1,0 +1,17 @@
+package com.rorpage.purtyweather.database.daos
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.rorpage.purtyweather.database.entities.CurrentTemperature
+
+@Dao
+interface CurrentTemperatureDAO {
+
+    @Query("SELECT * FROM currenttemperature WHERE id = 1")
+    fun getCurrentTemperature(): CurrentTemperature
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertCurrentTemperature( currentTemperature: CurrentTemperature)
+}

--- a/app/src/main/java/com/rorpage/purtyweather/database/daos/CurrentTemperatureDAO.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/database/daos/CurrentTemperatureDAO.kt
@@ -1,5 +1,6 @@
 package com.rorpage.purtyweather.database.daos
 
+import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -10,7 +11,7 @@ import com.rorpage.purtyweather.database.entities.CurrentTemperature
 interface CurrentTemperatureDAO {
 
     @Query("SELECT * FROM currenttemperature WHERE id = 1")
-    fun getCurrentTemperature(): CurrentTemperature
+    fun getCurrentTemperature(): LiveData<CurrentTemperature>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertCurrentTemperature( currentTemperature: CurrentTemperature)

--- a/app/src/main/java/com/rorpage/purtyweather/database/entities/CurrentTemperature.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/database/entities/CurrentTemperature.kt
@@ -9,6 +9,4 @@ data class CurrentTemperature(
         val id: Int,
         val temperature: Double,
         val feelsLike: Double
-) {
-
-}
+)

--- a/app/src/main/java/com/rorpage/purtyweather/database/entities/CurrentTemperature.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/database/entities/CurrentTemperature.kt
@@ -1,0 +1,14 @@
+package com.rorpage.purtyweather.database.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class CurrentTemperature(
+        @PrimaryKey()
+        val id: Int,
+        val temperature: Double,
+        val feelsLike: Double
+) {
+
+}

--- a/app/src/main/java/com/rorpage/purtyweather/di/DatabaseModule.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/di/DatabaseModule.kt
@@ -1,0 +1,34 @@
+package com.rorpage.purtyweather.di
+
+import android.content.Context
+import androidx.room.Room
+import com.rorpage.purtyweather.database.AppDatabase
+import com.rorpage.purtyweather.database.daos.CurrentTemperatureDAO
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Singleton
+
+@InstallIn(ApplicationComponent::class)
+@Module
+class DatabaseModule {
+    @Provides
+    fun provideCurrentTemperatureDAO(appDatabase: AppDatabase): CurrentTemperatureDAO {
+        return appDatabase.currentTemperatureDAO()
+    }
+
+    @Provides
+    @Singleton
+    fun provideAppDatabase(@ApplicationContext appContext: Context): AppDatabase {
+        return Room.databaseBuilder(
+                appContext,
+                AppDatabase::class.java,
+                "com.rorpage.purtyweather.roomdb"
+        )
+                // TODO: 10/17/20 We will want to add support for backgrounding these, probably with coroutines
+                .allowMainThreadQueries()
+                .build()
+    }
+}

--- a/app/src/main/java/com/rorpage/purtyweather/models/BaseWeatherInfoUnit.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/models/BaseWeatherInfoUnit.kt
@@ -12,6 +12,5 @@ open class BaseWeatherInfoUnit {
     var visibility = 0
     var wind_speed = 0.0
     var wind_deg = 0
-    @JvmField
     var weather: List<Weather>? = null
 }

--- a/app/src/main/java/com/rorpage/purtyweather/models/DailyWeatherInfoUnit.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/models/DailyWeatherInfoUnit.kt
@@ -1,7 +1,6 @@
 package com.rorpage.purtyweather.models
 
 class DailyWeatherInfoUnit : BaseWeatherInfoUnit() {
-    @JvmField
     var temp: Temperature? = null
     var feels_like: BaseTemperature? = null
 }

--- a/app/src/main/java/com/rorpage/purtyweather/models/Temperature.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/models/Temperature.kt
@@ -1,8 +1,6 @@
 package com.rorpage.purtyweather.models
 
 class Temperature : BaseTemperature() {
-    @JvmField
     var min = 0.0
-    @JvmField
     var max = 0.0
 }

--- a/app/src/main/java/com/rorpage/purtyweather/models/WeatherInfoUnit.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/models/WeatherInfoUnit.kt
@@ -3,6 +3,6 @@ package com.rorpage.purtyweather.models
 class WeatherInfoUnit : BaseWeatherInfoUnit() {
     var temp = 0.0
 
-    // TODO: 10/9/20 figure out how to make the model name different than the JSON name (feelsLike)
+    // TODO: 10/9/20 figure out how to make the model name different than the JSON name (feelsLike) [THIS WILL HAPPEN WITH SWITCH TO RETROFIT AND LIKELY MOSHI]
     var feels_like = 0.0
 }

--- a/app/src/main/java/com/rorpage/purtyweather/models/WeatherInfoUnit.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/models/WeatherInfoUnit.kt
@@ -1,10 +1,8 @@
 package com.rorpage.purtyweather.models
 
 class WeatherInfoUnit : BaseWeatherInfoUnit() {
-    @JvmField
     var temp = 0.0
 
     // TODO: 10/9/20 figure out how to make the model name different than the JSON name (feelsLike)
-    @JvmField
     var feels_like = 0.0
 }

--- a/app/src/main/java/com/rorpage/purtyweather/models/WeatherResponse.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/models/WeatherResponse.kt
@@ -1,10 +1,7 @@
 package com.rorpage.purtyweather.models
 
 class WeatherResponse {
-    // these annotations can be removed if entire project is converted to Kotlin
-    @JvmField
     var current: WeatherInfoUnit? = null
     var hourly: List<WeatherInfoUnit>? = null
-    @JvmField
     var daily: List<DailyWeatherInfoUnit>? = null
 }

--- a/app/src/main/java/com/rorpage/purtyweather/services/UpdateWeatherService.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/services/UpdateWeatherService.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 @AndroidEntryPoint
 class UpdateWeatherService : BaseService() {
@@ -85,7 +86,7 @@ class UpdateWeatherService : BaseService() {
         return if (temperature != null) {
             try {
                 val iconFormat = if (temperature < 0) "tempn%d" else "temp%d"
-                val iconName = String.format(iconFormat, temperature.toInt())
+                val iconName = String.format(iconFormat, temperature.roundToInt())
                 getIconIdFromResources(iconName, "drawable")
             } catch (e: Exception) {
                 Timber.e(e)

--- a/app/src/main/java/com/rorpage/purtyweather/services/UpdateWeatherService.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/services/UpdateWeatherService.kt
@@ -8,13 +8,19 @@ import com.android.volley.toolbox.Volley
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.rorpage.purtyweather.BuildConfig
+import com.rorpage.purtyweather.database.daos.CurrentTemperatureDAO
+import com.rorpage.purtyweather.database.entities.CurrentTemperature
 import com.rorpage.purtyweather.managers.NotificationManager
 import com.rorpage.purtyweather.models.WeatherResponse
 import com.rorpage.purtyweather.util.GsonRequest
+import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import java.util.*
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class UpdateWeatherService : BaseService() {
+    @Inject lateinit var currentTemperatureDAO: CurrentTemperatureDAO
     private lateinit var fusedLocationClient: FusedLocationProviderClient
     private lateinit var mNotificationManager: NotificationManager
     override fun onCreate() {
@@ -65,6 +71,11 @@ class UpdateWeatherService : BaseService() {
                     today.weather!![0].description)
             val iconId = getIconId(currentTemperature)
             mNotificationManager.sendNotification(title, subtitle, iconId)
+            // TODO: 10/17/20 this is where we should save things to database for now, will change with refactor to retrofit
+            currentTemperatureDAO.insertCurrentTemperature(
+                    CurrentTemperature(1,
+                            currentTemperature ?: -40.0,
+                    weatherResponse.current?.feels_like ?: -40.0))
         }
         ) { error -> Timber.e(error) }
         queue.add(weatherResponseGsonRequest)

--- a/app/src/main/java/com/rorpage/purtyweather/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/dashboard/DashboardFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.ViewModelProviders
 import com.rorpage.purtyweather.R
 
 class DashboardFragment : Fragment() {

--- a/app/src/main/java/com/rorpage/purtyweather/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/dashboard/DashboardFragment.kt
@@ -6,15 +6,15 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProviders
 import com.rorpage.purtyweather.R
 
 class DashboardFragment : Fragment() {
-    private lateinit var dashboardViewModel: DashboardViewModel
+    private val dashboardViewModel: DashboardViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater,
                               container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        dashboardViewModel = ViewModelProviders.of(this).get(DashboardViewModel::class.java)
         val root = inflater.inflate(R.layout.fragment_dashboard, container, false)
         val textView = root.findViewById<TextView>(R.id.text_dashboard)
         dashboardViewModel.text.observe(viewLifecycleOwner, { s -> textView.text = s })

--- a/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.ViewModelProviders
 import com.rorpage.purtyweather.R
 
 class HomeFragment : Fragment() {
@@ -15,8 +14,10 @@ class HomeFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater,
                               container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val root = inflater.inflate(R.layout.fragment_home, container, false)
-        val textView = root.findViewById<TextView>(R.id.text_home)
-        homeViewModel.text.observe(viewLifecycleOwner, { s -> textView.text = s })
+        val dateTextView = root.findViewById<TextView>(R.id.todays_date)
+        val temperatureTextView = root.findViewById<TextView>(R.id.temperature)
+        homeViewModel.dateLiveData.observe(viewLifecycleOwner, { s -> dateTextView.text = s })
+        homeViewModel.temperatureLiveData.observe(viewLifecycleOwner, { s -> temperatureTextView.text = s })
         return root
     }
 }

--- a/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeFragment.kt
@@ -8,7 +8,9 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.rorpage.purtyweather.R
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class HomeFragment : Fragment() {
     private val homeViewModel: HomeViewModel by viewModels()
     override fun onCreateView(inflater: LayoutInflater,

--- a/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeFragment.kt
@@ -6,14 +6,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProviders
 import com.rorpage.purtyweather.R
 
 class HomeFragment : Fragment() {
-    private lateinit var homeViewModel: HomeViewModel
+    private val homeViewModel: HomeViewModel by viewModels()
     override fun onCreateView(inflater: LayoutInflater,
                               container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        homeViewModel = ViewModelProviders.of(this).get(HomeViewModel::class.java)
         val root = inflater.inflate(R.layout.fragment_home, container, false)
         val textView = root.findViewById<TextView>(R.id.text_home)
         homeViewModel.text.observe(viewLifecycleOwner, { s -> textView.text = s })

--- a/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeFragment.kt
@@ -8,10 +8,15 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.rorpage.purtyweather.R
+import com.rorpage.purtyweather.database.daos.CurrentTemperatureDAO
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlin.math.roundToInt
 
 @AndroidEntryPoint
 class HomeFragment : Fragment() {
+
+    @Inject lateinit var currentTemperatureDAO: CurrentTemperatureDAO
     private val homeViewModel: HomeViewModel by viewModels()
     override fun onCreateView(inflater: LayoutInflater,
                               container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -20,6 +25,22 @@ class HomeFragment : Fragment() {
         val temperatureTextView = root.findViewById<TextView>(R.id.temperature)
         homeViewModel.dateLiveData.observe(viewLifecycleOwner, { s -> dateTextView.text = s })
         homeViewModel.temperatureLiveData.observe(viewLifecycleOwner, { s -> temperatureTextView.text = s })
+
+        currentTemperatureDAO.getCurrentTemperature()
+                .observe(viewLifecycleOwner, { currentTemperature ->
+                    temperatureTextView.text = getString(
+                            R.string.temperature,
+                            currentTemperature.temperature.roundToInt()
+                    )
+                })
+
         return root
+    }
+
+    override fun onDestroyView() {
+        homeViewModel.dateLiveData.removeObservers(viewLifecycleOwner)
+        homeViewModel.temperatureLiveData.removeObservers(viewLifecycleOwner)
+        currentTemperatureDAO.getCurrentTemperature().removeObservers(viewLifecycleOwner)
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeViewModel.kt
@@ -3,17 +3,25 @@ package com.rorpage.purtyweather.ui.home
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 class HomeViewModel : ViewModel() {
-    private val mText: MutableLiveData<String> = MutableLiveData()
-    val text: LiveData<String>
-        get() = mText
+    private val dateText: MutableLiveData<String> = MutableLiveData()
+    val dateLiveData: LiveData<String>
+        get() = dateText
 
-    fun setText(text: String) {
-        mText.value = text
-    }
+    private val temperatureText: MutableLiveData<String> = MutableLiveData()
+    val temperatureLiveData: LiveData<String>
+        get() = temperatureText
+
+    private val localDateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+
+    private var temperature = 45
 
     init {
-        mText.value = "This is home fragment"
+        dateText.value = LocalDate.now().format(localDateFormatter)
+        temperatureText.value = "${temperature}°"
     }
 }

--- a/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/home/HomeViewModel.kt
@@ -18,10 +18,8 @@ class HomeViewModel : ViewModel() {
 
     private val localDateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
 
-    private var temperature = 45
-
     init {
         dateText.value = LocalDate.now().format(localDateFormatter)
-        temperatureText.value = "${temperature}°"
+        temperatureText.value = "-°"
     }
 }

--- a/app/src/main/java/com/rorpage/purtyweather/ui/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/notifications/NotificationsFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.ViewModelProviders
 import com.rorpage.purtyweather.R
 
 class NotificationsFragment : Fragment() {

--- a/app/src/main/java/com/rorpage/purtyweather/ui/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/ui/notifications/NotificationsFragment.kt
@@ -6,17 +6,17 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProviders
 import com.rorpage.purtyweather.R
 
 class NotificationsFragment : Fragment() {
-    private var notificationsViewModel: NotificationsViewModel? = null
+    private val notificationsViewModel: NotificationsViewModel by viewModels()
     override fun onCreateView(inflater: LayoutInflater,
                               container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        notificationsViewModel = ViewModelProviders.of(this).get(NotificationsViewModel::class.java)
         val root = inflater.inflate(R.layout.fragment_notifications, container, false)
         val textView = root.findViewById<TextView>(R.id.text_notifications)
-        notificationsViewModel!!.text.observe(viewLifecycleOwner, { s -> textView.text = s })
+        notificationsViewModel.text.observe(viewLifecycleOwner, { s -> textView.text = s })
         return root
     }
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,19 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <TextView
-        android:id="@+id/text_home"
+        android:id="@+id/todays_date"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
+        android:layout_margin="8dp"
         android:textAlignment="center"
-        android:textSize="20sp"
+        android:textSize="36sp"
+        android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/temperature"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAlignment="center"
+        android:textSize="100dp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/todays_date"
+        tools:ignore="SpUsage" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="title_home">Home</string>
     <string name="title_dashboard">Dashboard</string>
     <string name="title_notifications">Notifications</string>
+    <string name="temperature">%d˚</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,16 @@
 
 buildscript {
     ext.kotlin_version = '1.4.10'
+    ext.hilt_version = '2.28-alpha'
     repositories {
         google()
         jcenter()
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 14 23:27:25 EDT 2020
+#Sat Oct 17 12:01:39 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
This PR persists the current temperature to a Room DB making use of Hilt to inject the database DAO where needed. The home fragment observes the database table and updates the displayed temperature accordingly.

Work still to do (not an exhaustive list):
- Toggle theme light / dark depending on sunrise / sunset times. This is gated by parsing and persisting the rest of the API call fields but I thought we would do that after switching to retrofit.  
- Move database accesses to background thread. Room has coroutine suspend function support so we can use that. For now, I just allowed access on the main thread.
- Add repository layer that decides when to fetch data from db vs refreshing data from API (length of time and change in location could be decision points)
- Add view binding (getting rid of those findViewByID calls). This is just some technical debt we can tackle.
