### PR TITLE
move startForeground to onCreate, add flag to pending intent

### DIFF
--- a/app/src/main/java/com/rorpage/purtyweather/managers/NotificationManager.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/managers/NotificationManager.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -51,18 +52,16 @@ class NotificationManager(private val mContext: Context) {
         private get() {
             val intent = Intent(mContext, MainActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            return PendingIntent.getActivity(mContext, 0, intent, PendingIntent.FLAG_ONE_SHOT)
+            return PendingIntent.getActivity(mContext, 0, intent, FLAG_IMMUTABLE)
         }
 
     private fun buildNotificationChannelIfNeeded() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(PRIMARY_CHANNEL,
-                    mContext.getString(R.string.notification_channel_default),
-                    NotificationManager.IMPORTANCE_LOW)
-            channel.setShowBadge(false)
-            channel.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-            mNotificationManager.createNotificationChannel(channel)
-        }
+        val channel = NotificationChannel(PRIMARY_CHANNEL,
+                mContext.getString(R.string.notification_channel_default),
+                NotificationManager.IMPORTANCE_LOW)
+        channel.setShowBadge(false)
+        channel.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+        mNotificationManager.createNotificationChannel(channel)
     }
 
     companion object {

--- a/app/src/main/java/com/rorpage/purtyweather/services/UpdateWeatherService.kt
+++ b/app/src/main/java/com/rorpage/purtyweather/services/UpdateWeatherService.kt
@@ -46,12 +46,12 @@ class UpdateWeatherService : BaseService() {
         super.onCreate()
         mNotificationManager = NotificationManager(this)
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
+        startForeground(NotificationManager.NOTIFICATION_ID,
+            mNotificationManager.sendNotification("Loading..."))
     }
 
     override fun onHandleIntent(intent: Intent?) {
         super.onHandleIntent(intent)
-        startForeground(NotificationManager.NOTIFICATION_ID,
-                mNotificationManager.sendNotification("Loading..."))
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED &&
                 ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             Timber.e("Location permission not granted")


### PR DESCRIPTION
Small updates to fix starting the service on Android 12. Ideally we'd do a bigger refactor to move away from IntentService but I'm keeping this limited since the app is broken and this unblocks other development.